### PR TITLE
piv-ssh-agent: use a replace directive for piv-go

### DIFF
--- a/piv-ssh-agent/go.mod
+++ b/piv-ssh-agent/go.mod
@@ -5,4 +5,6 @@ module github.com/ericchiang/piv-go/piv-ssh-agent
 
 go 1.13
 
-require github.com/ericchiang/piv-go v0.0.0-20200120200652-e490845be217
+require github.com/ericchiang/piv-go v0.0.0
+
+replace github.com/ericchiang/piv-go => ../

--- a/piv-ssh-agent/go.sum
+++ b/piv-ssh-agent/go.sum
@@ -1,2 +1,0 @@
-github.com/ericchiang/piv-go v0.0.0-20200120200652-e490845be217 h1:AK9JWWsXKqp1lmEJP6S7zLKejuCXSbWxG6XzPI7hsNs=
-github.com/ericchiang/piv-go v0.0.0-20200120200652-e490845be217/go.mod h1:Y5FUAVCVwi0AX1QnwiaDBhZzKeMNdYSV1u+u7m+iw+k=


### PR DESCRIPTION
Instead of pinning against a specific version of piv-go, always use the
version from the same checkout.