### PR TITLE
piv: make Auth methods private

### DIFF
--- a/piv/piv.go
+++ b/piv/piv.go
@@ -259,7 +259,7 @@ func encodePIN(pin string) ([]byte, error) {
 	return data, nil
 }
 
-// AuthPIN attempts to authenticate against the card with the provided PIN.
+// authPIN attempts to authenticate against the card with the provided PIN.
 // The PIN is required to use and modify certain slots.
 //
 // After a specific number of authentication attemps with an invalid PIN,
@@ -267,7 +267,7 @@ func encodePIN(pin string) ([]byte, error) {
 // point the PUK must be used to unblock the PIN.
 //
 // Use DefaultPIN if the PIN hasn't been set.
-func (yk *YubiKey) AuthPIN(pin string) error {
+func (yk *YubiKey) authPIN(pin string) error {
 	tx, err := yk.begin()
 	if err != nil {
 		return err
@@ -384,12 +384,12 @@ type version struct {
 	patch byte
 }
 
-// AuthManagementKey attempts to authenticate against the card with the provided
+// authManagementKey attempts to authenticate against the card with the provided
 // management key. The management key is required to generate new keys or add
 // certificates to slots.
 //
 // Use DefaultManagementKey if the management key hasn't been set.
-func (yk *YubiKey) AuthManagementKey(key [24]byte) error {
+func (yk *YubiKey) authManagementKey(key [24]byte) error {
 	tx, err := yk.begin()
 	if err != nil {
 		return err

--- a/piv/piv_test.go
+++ b/piv/piv_test.go
@@ -110,7 +110,7 @@ func TestYubiKeyReset(t *testing.T) {
 	if err := yk.Reset(); err != nil {
 		t.Fatalf("resetting yubikey: %v", err)
 	}
-	if err := yk.AuthPIN(DefaultPIN); err != nil {
+	if err := yk.authPIN(DefaultPIN); err != nil {
 		t.Fatalf("login: %v", err)
 	}
 }
@@ -119,7 +119,7 @@ func TestYubiKeyLogin(t *testing.T) {
 	yk, close := newTestYubiKey(t)
 	defer close()
 
-	if err := yk.AuthPIN(DefaultPIN); err != nil {
+	if err := yk.authPIN(DefaultPIN); err != nil {
 		t.Fatalf("login: %v", err)
 	}
 }
@@ -128,7 +128,7 @@ func TestYubiKeyAuthenticate(t *testing.T) {
 	yk, close := newTestYubiKey(t)
 	defer close()
 
-	if err := yk.AuthManagementKey(DefaultManagementKey); err != nil {
+	if err := yk.authManagementKey(DefaultManagementKey); err != nil {
 		t.Errorf("authenticating: %v", err)
 	}
 }
@@ -145,7 +145,7 @@ func TestYubiKeySetManagementKey(t *testing.T) {
 	if err := yk.SetManagementKey(DefaultManagementKey, mgmtKey); err != nil {
 		t.Fatalf("setting management key: %v", err)
 	}
-	if err := yk.AuthManagementKey(mgmtKey); err != nil {
+	if err := yk.authManagementKey(mgmtKey); err != nil {
 		t.Errorf("authenticating with new management key: %v", err)
 	}
 	if err := yk.SetManagementKey(mgmtKey, DefaultManagementKey); err != nil {


### PR DESCRIPTION
Methods should take a PIN or management key instead of having global
auth methods on the YubiKey.